### PR TITLE
issue #5: added the komiser installation process through homebrew

### DIFF
--- a/docs/Introduction/installation.md
+++ b/docs/Introduction/installation.md
@@ -72,6 +72,28 @@ wget https://cli.komiser.io/3.0.5/osx/amd/komiser
 
 ### Homebrew installation
 
+You can install Komiser using Homebrew on macOS by following these steps:
+
+1. Open Terminal on your Mac.
+
+2. Install Homebrew if you haven't already by running the following command:
+
+`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
+
+3. Once Homebrew is installed, run the following command to add the Komiser tap:
+
+`brew tap komiserio/komiser`
+
+4. Finally, install Komiser by running the following command:
+
+`brew install komiser`
+
+5. After the installation is complete, you can verify that Komiser is installed by running the following command:
+
+`komiser --version`
+
+This should display the current version of Komiser installed on your system.
+
 ```
 brew update
 brew tap tailwarden/komiser

--- a/docs/Introduction/installation.md
+++ b/docs/Introduction/installation.md
@@ -5,6 +5,14 @@ sidebar_label: Installation
 ---
 # Installation
 
+## Prerequisites
+
+- Make sure that you have PostgresSQL or SQLite installed on your computer.
+
+- Make sure to create a directory where you want to install Komiser.
+
+- Create a TOML configuration file called `config.toml` in the directory where you installed Komiser. The data will be inserted in it later on in this guide.
+
 ## Getting started
 
 You can install the CLI with a `curl` utility script or by downloading the binary from the releases page. Once installed you'll get the `komiser` command.
@@ -35,9 +43,7 @@ For AMD architecture (Intel Chip)
 wget https://cli.komiser.io/3.0.5/osx/amd/komiser
 ```
 
-> Note
-    Make sure to add the execution permission to Komiser `chmod +x komiser`.
-
+> **Note: Make sure to add the execution permission to Komiser `chmod +x komiser`.**
 
 ### Homebrew installation
 

--- a/docs/Introduction/installation.md
+++ b/docs/Introduction/installation.md
@@ -13,6 +13,31 @@ sidebar_label: Installation
 
 - Create a TOML configuration file called `config.toml` in the directory where you installed Komiser. The data will be inserted in it later on in this guide.
 
+### What is Toml
+
+TOML (Tom's Obvious, Minimal Language) is a configuration file format that is designed to be easy to read and write for both humans and machines. It was created by Tom Preston-Werner, co-founder of GitHub.
+
+It has a simple structure, consisting of key-value pairs organized into tables, with the use of indentation to indicate nesting. It also supports various data types such as strings, integers, floats, booleans, arrays, and tables.
+
+Here is an example of a simple TOML configuration file:
+
+# This is a TOML document.
+
+    title = "Example Config File"
+
+    [database]
+    server = "localhost"
+    port = 3306
+    username = "admin"
+    password = "password123"
+
+    [server]
+    ip = "127.0.0.1"
+    port = 8080
+    debug = true
+
+In this example, there are two tables: **database** and **server**. The t**database** table contains information about the database server, such as the server name, port number, username, and password. The **server** table contains information about the application server, such as the IP address, port number, and a boolean flag to enable debugging.
+
 ## Getting started
 
 You can install the CLI with a `curl` utility script or by downloading the binary from the releases page. Once installed you'll get the `komiser` command.


### PR DESCRIPTION
There were some issues with Homebrew install on Mac M1. The Homebrew installation guide should be updated and that's why I sent the PR. See if it works.

@jakepage91 