### PR TITLE
Update link to `Edit this page` button

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -37,8 +37,15 @@ const config = {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl:
-            'https://github.com/tailwarden/komiser',
+          editUrl: function ({
+            locale,
+            version,
+            versionDocsDirPath,
+            docPath,
+            permalink,
+          }) {
+            return 'https://github.com/tailwarden/docs.komiser.io#how-to-contribute-to-the-documentation';
+          },
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
In order to avoid Docusaurus following the default behavior for the `docs` preset (which governs the "edit this page" button) which is to append the path of the `current` path  of the page you are on to the link in, provided in the `editUrl` field. I have had to add the function to `editUrl` and now the "Edit this page" button will always direct traffic to https://github.com/tailwarden/docs.komiser.io#how-to-contribute-to-the-documentation without appending additional paths to it. 