### PR TITLE
Document supported GCP providers

### DIFF
--- a/docs/Cloud Providers/gcp.md
+++ b/docs/Cloud Providers/gcp.md
@@ -8,9 +8,12 @@ sidebar_label: Google Cloud Platform (GCP)
 
 ## Supported resources
 
+- Certificate Manager
 - Cloud Storage Buckets
 - Compute Engine VM Instances
-
+- IAM Roles
+- IAM Service Accounts
+- SQL Instances
 
 ## Local Komiser CLI (Single account)
 


### PR DESCRIPTION
This PR adds the GCP providers in the documentation in an alphabetical order (for easy indexing for the bare eye) that are already merged PRs to develop:
- Certificate Manager https://github.com/tailwarden/komiser/pull/706
- IAM Roles https://github.com/tailwarden/komiser/pull/712
- IAM Service Accounts https://github.com/tailwarden/komiser/pull/713
- SQL Instances https://github.com/tailwarden/komiser/pull/710