### PR TITLE
fix: added postgres pre setup note

### DIFF
--- a/docs/Cloud Providers/aws.md
+++ b/docs/Cloud Providers/aws.md
@@ -67,6 +67,8 @@ Choose between these two methods of persisting your AWS Account data.
 [postgres]
 uri="postgres://postgres:komiser@localhost:5432/komiser?sslmode=disable"
 ```
+Note: For Postgres, Komiser anticipates the existence of a role `postgres` and a database `komiser` on the local Postgres server.
+
 #### SQLite
 ```
 # Add to config.toml file

--- a/docs/Cloud Providers/azure.md
+++ b/docs/Cloud Providers/azure.md
@@ -23,6 +23,8 @@ We've also added 2 methods of persisting your account data.
 [postgres]
 uri="postgres://postgres:komiser@localhost:5432/komiser?sslmode=disable"
 ```
+Note: For Postgres, Komiser anticipates the existence of a role `postgres` and a database `komiser` on the local Postgres server.
+
 ### SQLite
 
 ```

--- a/docs/Cloud Providers/civo.md
+++ b/docs/Cloud Providers/civo.md
@@ -26,6 +26,8 @@ We've also added 2 methods of persisting your account data.
 [postgres]
 uri="postgres://postgres:komiser@localhost:5432/komiser?sslmode=disable"
 ```
+Note: For Postgres, Komiser anticipates the existence of a role `postgres` and a database `komiser` on the local Postgres server.
+
 ### SQLite
 
 ```

--- a/docs/Cloud Providers/digital-ocean.md
+++ b/docs/Cloud Providers/digital-ocean.md
@@ -23,6 +23,8 @@ We've also added 2 methods of persisting your account data.
 [postgres]
 uri="postgres://postgres:komiser@localhost:5432/komiser?sslmode=disable"
 ```
+Note: For Postgres, Komiser anticipates the existence of a role `postgres` and a database `komiser` on the local Postgres server.
+
 ### SQLite
 
 ```

--- a/docs/Cloud Providers/gcp.md
+++ b/docs/Cloud Providers/gcp.md
@@ -33,8 +33,9 @@ We've also added 2 methods of persisting your account data.
 [postgres]
   uri="postgres://postgres:komiser@localhost:5432/komiser?sslmode=disable"
 ```
-### SQLite
+Note: For Postgres, Komiser anticipates the existence of a role `postgres` and a database `komiser` on the local Postgres server.
 
+### SQLite 
 ```
 [sqlite]
   file = "komiser.db"

--- a/docs/Cloud Providers/k8s.md
+++ b/docs/Cloud Providers/k8s.md
@@ -30,6 +30,8 @@ Choose between these two methods of persisting your Kubernetes cluster data.
 [postgres]
 uri="postgres://postgres:komiser@localhost:5432/komiser?sslmode=disable"
 ```
+Note: For Postgres, Komiser anticipates the existence of a role `postgres` and a database `komiser` on the local Postgres server.
+
 #### SQLite
 
 ```

--- a/docs/Cloud Providers/linode.md
+++ b/docs/Cloud Providers/linode.md
@@ -25,6 +25,8 @@ We've also added 2 methods of persisting your account data.
 [postgres]
 uri="postgres://postgres:komiser@localhost:5432/komiser?sslmode=disable"
 ```
+Note: For Postgres, Komiser anticipates the existence of a role `postgres` and a database `komiser` on the local Postgres server.
+
 ### SQLite
 
 ```

--- a/docs/Cloud Providers/mongodbatlas.md
+++ b/docs/Cloud Providers/mongodbatlas.md
@@ -22,6 +22,8 @@ We've also added 2 methods of persisting your account data.
 [postgres]
   uri="postgres://postgres:komiser@localhost:5432/komiser?sslmode=disable"
 ```
+Note: For Postgres, Komiser anticipates the existence of a role `postgres` and a database `komiser` on the local Postgres server.
+
 ### SQLite
 
 ```

--- a/docs/Cloud Providers/oci.md
+++ b/docs/Cloud Providers/oci.md
@@ -27,6 +27,8 @@ Choose between these two methods of persisting your OCI account data.
 [postgres]
 uri="postgres://postgres:komiser@localhost:5432/komiser?sslmode=disable"
 ```
+Note: For Postgres, Komiser anticipates the existence of a role `postgres` and a database `komiser` on the local Postgres server.
+
 #### SQLite
 
 ```

--- a/docs/Cloud Providers/ovh.md
+++ b/docs/Cloud Providers/ovh.md
@@ -10,6 +10,8 @@ Choose between these two methods of persisting your OVH account data.
 [postgres]
 uri="postgres://postgres:komiser@localhost:5432/komiser?sslmode=disable"
 ```
+Note: For Postgres, Komiser anticipates the existence of a role `postgres` and a database `komiser` on the local Postgres server.
+
 #### SQLite
 
 ```

--- a/docs/Cloud Providers/scaleway.md
+++ b/docs/Cloud Providers/scaleway.md
@@ -26,6 +26,8 @@ We've also added 2 methods of persisting your account data.
 [postgres]
 uri="postgres://postgres:komiser@localhost:5432/komiser?sslmode=disable"
 ```
+Note: For Postgres, Komiser anticipates the existence of a role `postgres` and a database `komiser` on the local Postgres server.
+
 ### SQLite
 
 ```

--- a/docs/Cloud Providers/tencent.md
+++ b/docs/Cloud Providers/tencent.md
@@ -20,6 +20,8 @@ We've also added 2 methods of persisting your account data.
 [postgres]
 uri="postgres://postgres:komiser@localhost:5432/komiser?sslmode=disable"
 ```
+Note: For Postgres, Komiser anticipates the existence of a role `postgres` and a database `komiser` on the local Postgres server.
+
 ### SQLite
 
 ```


### PR DESCRIPTION
In order to use postgres as a local database for komiser one needs to have a role `postgres` and a database `komiser` up in local postgress. 