### PR TITLE
Add: Specify Local Timezone for the Public Calendar

### DIFF
--- a/docs/Events/events.md
+++ b/docs/Events/events.md
@@ -10,6 +10,8 @@ This space is dedicated to our regular gatherings on Discord, where users, contr
 
 Whether you're keen on getting started as a contributor, seeking to understand more about our project, or desiring to connect with like-minded peers, you'll find our community meetings an invaluable resource. Additionally, this page hosts a public Google Calendar, featuring all upcoming events, keeping you updated and ensuring you never miss an opportunity to join in these collaborative sessions.
 
+> **📍NOTE:** The event timings mentioned in the calendar are according to the **(GMT+01:00) Western European Time** timezone. Be sure to change it according to your **local timezone** while adding the event to the calendar!
+
 <iframe src="https://calendar.google.com/calendar/embed?src=d7546d80fed8e35d769785a3cbe8849ef8fded7ccbebd170eadb474c99a950fb%40group.calendar.google.com&ctz=Europe%2FParis" width="800" height="600" frameborder="0" scrolling="no"/>
 
 Make sure to subscribe to the calendar to make sure you are clued in to all the upcoming live workshops and AMA sessions too!


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] 📝 Documentation Update

## Description

The timings mentioned in the events calendar are in `(GMT+01:00) Western European Time - Lisbon` timezone. This PR adds a note for the readers to change the timings according to their local timezones while adding the event to their respective calendars.


## Mobile & Desktop Screenshots/Recordings

![Screenshot 2023-07-25 at 5 43 39 AM](https://github.com/tailwarden/docs.komiser.io/assets/72245772/7c9d4f94-635a-4587-87ae-c95b482fb700)

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [X] 📓 docs.komiser.io
- [ ] 📕 storybook
- [ ] 🗒 Code comment intelliSense
- [ ] 🙅 no documentation needed
